### PR TITLE
Fix typo in objctypes.m

### DIFF
--- a/csrc/objctypes.m
+++ b/csrc/objctypes.m
@@ -7,7 +7,7 @@
 char *
 objc_get_debug_description(id obj)
 {
-    if (class_comformsToProtocol(object_getClass(obj), @protocol(NSObject))) {
+    if (class_conformsToProtocol(object_getClass(obj), @protocol(NSObject))) {
         return [[obj debugDescription] UTF8String];
     }
     else {


### PR DESCRIPTION


<!-- readthedocs-preview objctypes start -->
----
📚 Documentation preview 📚: https://objctypes--42.org.readthedocs.build/en/42/

<!-- readthedocs-preview objctypes end -->