### PR TITLE
Introduce PEP 639: Use `license-files` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 1 - Planning",
   "Environment :: MacOS X :: Cocoa",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: The Unlicense (Unlicense)",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: iOS",
   "Programming Language :: Objective C",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "objctypes"
 description = "Use Objective-C features in Python"
 readme = "README.md"
 requires-python = ">=3.13"
-license = { file = "LICENSE.md" }
+license = "Unlicense"
+license-files = ["LICENSE.md"]
 keywords = ["objctypes", "objc", "Objective-C", "ObjectiveC"]
 classifiers = [
   "Development Status :: 1 - Planning",


### PR DESCRIPTION
Introduce [PEP 639](https://peps.python.org/pep-0639/)

<!-- readthedocs-preview objctypes start -->
----
📚 Documentation preview 📚: https://objctypes--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview objctypes end -->