### PR TITLE
Remove `fail-fast` from GitHub Actions workflow strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,6 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4.2.2


### PR DESCRIPTION


<!-- readthedocs-preview objctypes start -->
----
📚 Documentation preview 📚: https://objctypes--122.org.readthedocs.build/en/122/

<!-- readthedocs-preview objctypes end -->