### PR TITLE
Stop installing default dependency-groups in `uv run` commands in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Install dependencies
       run: uv sync --group gh-actions --no-default-groups
     - name: Type Check with mypy
-      run: uv run mypy .
+      run: uv run --no-default-groups mypy .
     - name: Test with pytest
-      run: uv run pytest
+      run: uv run --no-default-groups pytest
     - name: Prune uv cache
       run: uv cache prune --ci
 


### PR DESCRIPTION


<!-- readthedocs-preview objctypes start -->
----
📚 Documentation preview 📚: https://objctypes--124.org.readthedocs.build/en/124/

<!-- readthedocs-preview objctypes end -->