### PR TITLE
Change `ObjCClass` representation

### DIFF
--- a/csrc/objcclass.c
+++ b/csrc/objcclass.c
@@ -21,7 +21,7 @@ ObjCClass_repr(ObjCClassObject *self)
     if (self->value == NULL) {
         return PyUnicode_FromString("<class 'ObjCObject'>");
     }
-    return PyUnicode_FromFormat("ObjCClass('%s')", class_getName(self->value));
+    return PyUnicode_FromFormat("<ObjCClass '%s'>", class_getName(self->value));
 }
 
 // ObjCClass.address

--- a/tests/test_objcclass.py
+++ b/tests/test_objcclass.py
@@ -60,9 +60,9 @@ def test_objcclass_repr() -> None:
     NSString = ObjCClass("NSString")  # noqa: N806
     NSNumber = ObjCClass("NSNumber")  # noqa: N806
 
-    assert repr(NSObject) == "ObjCClass('NSObject')"
-    assert repr(NSString) == "ObjCClass('NSString')"
-    assert repr(NSNumber) == "ObjCClass('NSNumber')"
+    assert repr(NSObject) == "<ObjCClass 'NSObject'>"
+    assert repr(NSString) == "<ObjCClass 'NSString'>"
+    assert repr(NSNumber) == "<ObjCClass 'NSNumber'>"
 
 
 def test_objcclass_from_address() -> None:


### PR DESCRIPTION
Before:
```python
>>> ObjCClass("NSObject")
ObjCClass('NSObject')
```

After:
```python
>>> ObjCClass("NSObject")
<ObjCClass 'NSObject'>
```

<!-- readthedocs-preview objctypes start -->
----
📚 Documentation preview 📚: https://objctypes--127.org.readthedocs.build/en/127/

<!-- readthedocs-preview objctypes end -->